### PR TITLE
Conn.StatsExpect() for querying expectation stats per CPU

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -440,3 +440,28 @@ func (c *Conn) Stats() ([]Stats, error) {
 
 	return unmarshalStats(msgs)
 }
+
+// StatsExpect returns a list of StatsExpect structures, one per CPU present in the machine.
+// Each StatsExpect structure indicates how many Expect entries were initialized,
+// created or deleted on each CPU.
+func (c *Conn) StatsExpect() ([]StatsExpect, error) {
+
+	req, err := netfilter.MarshalNetlink(
+		netfilter.Header{
+			SubsystemID: netfilter.NFSubsysCTNetlinkExp,
+			MessageType: netfilter.MessageType(ctExpGetStatsCPU),
+			Family:      netfilter.ProtoUnspec,
+			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsDump,
+		}, nil)
+
+	if err != nil {
+		return nil, err
+	}
+
+	msgs, err := c.conn.Query(req)
+	if err != nil {
+		return nil, err
+	}
+
+	return unmarshalStatsExpect(msgs)
+}

--- a/stats_integration_test.go
+++ b/stats_integration_test.go
@@ -22,3 +22,17 @@ func TestConnStats(t *testing.T) {
 		assert.EqualValues(t, i, s.CPUID)
 	}
 }
+
+func TestConnStatsExpect(t *testing.T) {
+
+	c, err := makeNSConn()
+	require.NoError(t, err)
+
+	statsExpect, err := c.StatsExpect()
+	require.NoError(t, err)
+
+	for i, s := range statsExpect {
+		// Make sure the array index corresponds to the CPUID of each entry.
+		assert.EqualValues(t, i, s.CPUID)
+	}
+}


### PR DESCRIPTION
Added `struct StatsExpect` and `Conn.StatsExpect()` API method to query statistics about the Expect table.