### PR TITLE
Conn.Count() for querying global conntrack count

### DIFF
--- a/stats.go
+++ b/stats.go
@@ -148,3 +148,19 @@ func unmarshalStatsExpect(nlm []netlink.Message) ([]StatsExpect, error) {
 
 	return stats, nil
 }
+
+// unmarshalStatsGlobal unmarshals the global Conntrack counter from a netlink.Message.
+func unmarshalStatsGlobal(nlm netlink.Message) (uint32, error) {
+
+	_, nfa, err := netfilter.UnmarshalNetlink(nlm)
+	if err != nil {
+		return 0, err
+	}
+
+	// Assert the first (and only) attribute to be a GlobalEntries
+	if at := nfa[0].Type; globalStatsType(at) != ctaStatsGlobalEntries {
+		return 0, fmt.Errorf(errAttributeUnknown, at)
+	}
+
+	return nfa[0].Uint32(), nil
+}

--- a/stats_integration_test.go
+++ b/stats_integration_test.go
@@ -3,6 +3,7 @@
 package conntrack
 
 import (
+	"net"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -35,4 +36,38 @@ func TestConnStatsExpect(t *testing.T) {
 		// Make sure the array index corresponds to the CPUID of each entry.
 		assert.EqualValues(t, i, s.CPUID)
 	}
+}
+
+func TestConnStatsGlobal(t *testing.T) {
+
+	c, err := makeNSConn()
+	require.NoError(t, err)
+
+	numFlows := 42
+
+	var f Flow
+
+	// Create IPv4 flows
+	for i := 1; i <= numFlows; i++ {
+		f = NewFlow(6, 0, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8), 1234, uint16(i), 120, 0)
+
+		err = c.Create(f)
+		require.NoError(t, err, "creating IPv4 flow", i)
+	}
+
+	// Create IPv6 flows
+	for i := 1; i <= numFlows; i++ {
+		err = c.Create(NewFlow(
+			17, 0,
+			net.ParseIP("2a00:1450:400e:804::200e"),
+			net.ParseIP("2a00:1450:400e:804::200f"),
+			1234, uint16(i), 120, 0,
+		))
+		require.NoError(t, err, "creating IPv6 flow", i)
+	}
+
+	count, err := c.Count()
+	require.NoError(t, err, "query flow count")
+
+	assert.EqualValues(t, numFlows*2, count)
 }

--- a/stats_test.go
+++ b/stats_test.go
@@ -140,7 +140,7 @@ func TestStatsExpectUnmarshal(t *testing.T) {
 	assert.EqualError(t, se.unmarshal([]netfilter.Attribute{{Type: 255}}), "attribute type '255' unknown")
 }
 
-func TestUnmarshalExpectStatsError(t *testing.T) {
+func TestUnmarshalStatsExpectError(t *testing.T) {
 
 	_, err := unmarshalStatsExpect([]netlink.Message{{}})
 	assert.EqualError(t, err, "expected at least 4 bytes in netlink message payload")
@@ -148,5 +148,16 @@ func TestUnmarshalExpectStatsError(t *testing.T) {
 	// Use netfilter.MarshalNetlink to assemble a Netlink message with a single attribute of unknown type
 	nlm, _ := netfilter.MarshalNetlink(netfilter.Header{}, []netfilter.Attribute{{Type: 255}})
 	_, err = unmarshalStatsExpect([]netlink.Message{nlm})
+	assert.EqualError(t, err, "attribute type '255' unknown")
+}
+
+func TestUnmarshalStatsGlobalError(t *testing.T) {
+
+	_, err := unmarshalStatsGlobal(netlink.Message{})
+	assert.EqualError(t, err, "expected at least 4 bytes in netlink message payload")
+
+	// Use netfilter.MarshalNetlink to assemble a Netlink message with a single attribute of unknown type
+	nlm, _ := netfilter.MarshalNetlink(netfilter.Header{}, []netfilter.Attribute{{Type: 255}})
+	_, err = unmarshalStatsGlobal(nlm)
 	assert.EqualError(t, err, "attribute type '255' unknown")
 }


### PR DESCRIPTION
Fixes #4

Fast Flow counter query.