### PR TITLE
Semaphore 2.0 - GOPATH and SEMAPHORE_GIT_DIR workaround

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -15,7 +15,16 @@ blocks:
           - go get github.com/mattn/goveralls
           - go get -t -tags=integration -d -v ./...
       jobs:
-        - name: Run Integration Test Suite
+        - name: Integration
           commands:
             - make integration
-            - $GOPATH/bin/goveralls -coverprofile cover-int.out -service semaphore -repotoken "$COVERALLS_REPO_TOKEN"
+            # GOPATH/bin is not in PATH, so needs to be referred to explicitly
+            - $GOPATH/bin/goveralls -coverprofile cover-int.out -service semaphore2 -repotoken "$COVERALLS_REPO_TOKEN"
+      # Workaround for Semaphore 2.0 beta until Go repositories are automatically cloned into GOPATH
+      env_vars:
+        - name: GOPATH
+          value: /home/semaphore/go
+        - name: SEMAPHORE_GIT_DIR
+          value: /home/semaphore/go/src/github.com/ti-mo/conntrack
+      secrets:
+        - name: coveralls-conntrack


### PR DESCRIPTION
Temporarily define our own GOPATH and SEMAPHORE_GIT_DIR until Go is fully supported.