### PR TITLE
Update to latest netlink library

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -116,7 +116,7 @@ func (c *Conn) Dump() ([]Flow, error) {
 			SubsystemID: netfilter.NFSubsysCTNetlink,
 			MessageType: netfilter.MessageType(ctGet),
 			Family:      netfilter.ProtoUnspec, // ProtoUnspec dumps both IPv4 and IPv6
-			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsDump,
+			Flags:       netlink.Request | netlink.Dump,
 		},
 		nil)
 
@@ -141,7 +141,7 @@ func (c *Conn) DumpFilter(f Filter) ([]Flow, error) {
 			SubsystemID: netfilter.NFSubsysCTNetlink,
 			MessageType: netfilter.MessageType(ctGet),
 			Family:      netfilter.ProtoUnspec, // ProtoUnspec dumps both IPv4 and IPv6
-			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsDump,
+			Flags:       netlink.Request | netlink.Dump,
 		},
 		f.marshal())
 
@@ -166,7 +166,7 @@ func (c *Conn) DumpExpect() ([]Expect, error) {
 			SubsystemID: netfilter.NFSubsysCTNetlinkExp,
 			MessageType: netfilter.MessageType(ctGet),
 			Family:      netfilter.ProtoUnspec, // ProtoUnspec dumps both IPv4 and IPv6
-			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsDump | netlink.HeaderFlagsAcknowledge,
+			Flags:       netlink.Request | netlink.Dump | netlink.Acknowledge,
 		},
 		nil)
 
@@ -190,7 +190,7 @@ func (c *Conn) Flush() error {
 			SubsystemID: netfilter.NFSubsysCTNetlink,
 			MessageType: netfilter.MessageType(ctDelete),
 			Family:      netfilter.ProtoUnspec, // Family is ignored for flush
-			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsAcknowledge,
+			Flags:       netlink.Request | netlink.Acknowledge,
 		},
 		nil)
 
@@ -215,7 +215,7 @@ func (c *Conn) FlushFilter(f Filter) error {
 			SubsystemID: netfilter.NFSubsysCTNetlink,
 			MessageType: netfilter.MessageType(ctDelete),
 			Family:      netfilter.ProtoUnspec, // Family is ignored for flush
-			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsAcknowledge,
+			Flags:       netlink.Request | netlink.Acknowledge,
 		},
 		f.marshal())
 
@@ -254,8 +254,8 @@ func (c *Conn) Create(f Flow) error {
 			SubsystemID: netfilter.NFSubsysCTNetlink,
 			MessageType: netfilter.MessageType(ctNew),
 			Family:      pf,
-			Flags: netlink.HeaderFlagsRequest | netlink.HeaderFlagsAcknowledge |
-				netlink.HeaderFlagsExcl | netlink.HeaderFlagsCreate,
+			Flags: netlink.Request | netlink.Acknowledge |
+				netlink.Excl | netlink.Create,
 		}, attrs)
 
 	if err != nil {
@@ -289,8 +289,8 @@ func (c *Conn) CreateExpect(ex Expect) error {
 			SubsystemID: netfilter.NFSubsysCTNetlinkExp,
 			MessageType: netfilter.MessageType(ctExpNew),
 			Family:      pf,
-			Flags: netlink.HeaderFlagsRequest | netlink.HeaderFlagsAcknowledge |
-				netlink.HeaderFlagsExcl | netlink.HeaderFlagsCreate,
+			Flags: netlink.Request | netlink.Acknowledge |
+				netlink.Excl | netlink.Create,
 		}, attrs)
 
 	if err != nil {
@@ -327,7 +327,7 @@ func (c *Conn) Get(f Flow) (Flow, error) {
 			SubsystemID: netfilter.NFSubsysCTNetlink,
 			MessageType: netfilter.MessageType(ctGet),
 			Family:      pf,
-			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsAcknowledge,
+			Flags:       netlink.Request | netlink.Acknowledge,
 		}, attrs)
 
 	if err != nil {
@@ -376,7 +376,7 @@ func (c *Conn) Update(f Flow) error {
 			SubsystemID: netfilter.NFSubsysCTNetlink,
 			MessageType: netfilter.MessageType(ctNew),
 			Family:      pf,
-			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsAcknowledge,
+			Flags:       netlink.Request | netlink.Acknowledge,
 		}, attrs)
 
 	if err != nil {
@@ -412,7 +412,7 @@ func (c *Conn) Delete(f Flow) error {
 			SubsystemID: netfilter.NFSubsysCTNetlink,
 			MessageType: netfilter.MessageType(ctDelete),
 			Family:      pf,
-			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsAcknowledge,
+			Flags:       netlink.Request | netlink.Acknowledge,
 		}, attrs)
 
 	if err != nil {
@@ -437,7 +437,7 @@ func (c *Conn) Stats() ([]Stats, error) {
 			SubsystemID: netfilter.NFSubsysCTNetlink,
 			MessageType: netfilter.MessageType(ctGetStatsCPU),
 			Family:      netfilter.ProtoUnspec,
-			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsDump,
+			Flags:       netlink.Request | netlink.Dump,
 		}, nil)
 
 	if err != nil {
@@ -462,7 +462,7 @@ func (c *Conn) StatsExpect() ([]StatsExpect, error) {
 			SubsystemID: netfilter.NFSubsysCTNetlinkExp,
 			MessageType: netfilter.MessageType(ctExpGetStatsCPU),
 			Family:      netfilter.ProtoUnspec,
-			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsDump,
+			Flags:       netlink.Request | netlink.Dump,
 		}, nil)
 
 	if err != nil {
@@ -491,7 +491,7 @@ func (c *Conn) StatsGlobal() (StatsGlobal, error) {
 			SubsystemID: netfilter.NFSubsysCTNetlink,
 			MessageType: netfilter.MessageType(ctGetStats),
 			Family:      netfilter.ProtoUnspec,
-			Flags:       netlink.HeaderFlagsRequest | netlink.HeaderFlagsDump | netlink.HeaderFlagsAcknowledge,
+			Flags:       netlink.Request | netlink.Dump | netlink.Acknowledge,
 		}, nil)
 
 	var sg StatsGlobal

--- a/conn_test.go
+++ b/conn_test.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/mdlayher/netlink"
 	"github.com/stretchr/testify/assert"
-
 	"github.com/ti-mo/conntrack"
 	"github.com/ti-mo/netfilter"
 )
@@ -18,7 +17,7 @@ func TestConnDialError(t *testing.T) {
 	// Attempt to open a Netlink socket into a netns that is highly unlikely
 	// to exist, so we can catch an error from Dial.
 	_, err := conntrack.Dial(&netlink.Config{NetNS: 1337})
-	assert.EqualError(t, err, "bad file descriptor")
+	assert.EqualError(t, err, "setns: bad file descriptor")
 }
 
 func ExampleConn_createUpdateFlow() {

--- a/event.go
+++ b/event.go
@@ -38,7 +38,7 @@ func (et *eventType) unmarshal(h netfilter.Header) error {
 		case ctNew:
 			// Since the MessageType is only of kind new, get or delete,
 			// the header's flags are used to distinguish between NEW and UPDATE.
-			if h.Flags&(netlink.HeaderFlagsCreate|netlink.HeaderFlagsExcl) != 0 {
+			if h.Flags&(netlink.Create|netlink.Excl) != 0 {
 				*et = EventNew
 			} else {
 				*et = EventUpdate

--- a/event_integration_test.go
+++ b/event_integration_test.go
@@ -7,12 +7,14 @@ import (
 	"os"
 	"testing"
 
-	"github.com/mdlayher/netlink"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/mdlayher/netlink"
 	"github.com/ti-mo/netfilter"
-	"golang.org/x/sys/unix"
 )
 
 func TestConnListen(t *testing.T) {
@@ -36,9 +38,9 @@ func TestConnListen(t *testing.T) {
 	go func() {
 		err, ok := <-errChan
 		if ok {
-			opErr := errors.Cause(err)
-			require.IsType(t, &netlink.OpError{}, opErr)
-			require.Equal(t, opErr.(*netlink.OpError).Err, os.NewSyscallError("recvmsg", unix.EBADF))
+			opErr, ok := errors.Cause(err).(*netlink.OpError)
+			require.True(t, ok)
+			require.EqualError(t, os.NewSyscallError("recvmsg", unix.EBADF), opErr.Err.Error())
 		}
 	}()
 

--- a/event_integration_test.go
+++ b/event_integration_test.go
@@ -4,15 +4,15 @@ package conntrack
 
 import (
 	"net"
+	"os"
 	"testing"
 
 	"github.com/mdlayher/netlink"
 	"github.com/pkg/errors"
-	"github.com/ti-mo/netfilter"
-	"golang.org/x/sys/unix"
-
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/ti-mo/netfilter"
+	"golang.org/x/sys/unix"
 )
 
 func TestConnListen(t *testing.T) {
@@ -36,7 +36,9 @@ func TestConnListen(t *testing.T) {
 	go func() {
 		err, ok := <-errChan
 		if ok {
-			require.Equal(t, errors.Cause(err), unix.EBADF)
+			opErr := errors.Cause(err)
+			require.IsType(t, &netlink.OpError{}, opErr)
+			require.Equal(t, opErr.(*netlink.OpError), os.NewSyscallError("recvmsg", unix.EBADF))
 		}
 	}()
 

--- a/event_integration_test.go
+++ b/event_integration_test.go
@@ -38,7 +38,7 @@ func TestConnListen(t *testing.T) {
 		if ok {
 			opErr := errors.Cause(err)
 			require.IsType(t, &netlink.OpError{}, opErr)
-			require.Equal(t, opErr.(*netlink.OpError), os.NewSyscallError("recvmsg", unix.EBADF))
+			require.Equal(t, opErr.(*netlink.OpError).Err, os.NewSyscallError("recvmsg", unix.EBADF))
 		}
 	}()
 

--- a/event_test.go
+++ b/event_test.go
@@ -25,7 +25,7 @@ var eventTypeTests = []struct {
 		nfh: netfilter.Header{
 			SubsystemID: netfilter.NFSubsysCTNetlink,
 			MessageType: netfilter.MessageType(ctNew),
-			Flags:       netlink.HeaderFlagsCreate | netlink.HeaderFlagsExcl,
+			Flags:       netlink.Create | netlink.Excl,
 		},
 		et: EventNew,
 	},
@@ -112,7 +112,7 @@ var eventTests = []struct {
 		name: "correct empty new flow event",
 		nfh: netfilter.Header{
 			SubsystemID: netfilter.NFSubsysCTNetlink,
-			Flags:       netlink.HeaderFlagsCreate | netlink.HeaderFlagsExcl,
+			Flags:       netlink.Create | netlink.Excl,
 		},
 		e: Event{
 			Type: EventNew,

--- a/expect_integration_test.go
+++ b/expect_integration_test.go
@@ -6,9 +6,12 @@ import (
 	"net"
 	"testing"
 
-	"github.com/mdlayher/netlink"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
 	"github.com/stretchr/testify/require"
+
+	"github.com/mdlayher/netlink"
 )
 
 // No meaningful integration test possible until we can figure out how
@@ -62,9 +65,9 @@ func TestConnCreateExpect(t *testing.T) {
 		Class:    0x30,
 	}
 
-	opErr := errors.Cause(c.CreateExpect(ex))
+	err = c.CreateExpect(ex)
 
-	require.IsType(t, &netlink.OpError{}, opErr)
-
-	require.EqualError(t, opErr, "netlink receive: invalid argument", ex)
+	opErr, ok := errors.Cause(err).(*netlink.OpError)
+	require.True(t, ok)
+	require.EqualError(t, unix.EINVAL, opErr.Err.Error())
 }

--- a/expect_integration_test.go
+++ b/expect_integration_test.go
@@ -6,6 +6,8 @@ import (
 	"net"
 	"testing"
 
+	"github.com/mdlayher/netlink"
+	"github.com/pkg/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -60,6 +62,9 @@ func TestConnCreateExpect(t *testing.T) {
 		Class:    0x30,
 	}
 
-	err = c.CreateExpect(ex)
-	require.EqualError(t, err, "error executing Netlink query: invalid argument", ex)
+	opErr := errors.Cause(c.CreateExpect(ex))
+
+	require.IsType(t, &netlink.OpError{}, opErr)
+
+	require.EqualError(t, opErr, "netlink receive: invalid argument", ex)
 }

--- a/flow_integration_test.go
+++ b/flow_integration_test.go
@@ -6,11 +6,13 @@ import (
 	"net"
 	"testing"
 
-	"github.com/mdlayher/netlink"
 	"github.com/pkg/errors"
+	"golang.org/x/sys/unix"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/unix"
+
+	"github.com/mdlayher/netlink"
 )
 
 // Create a given number of flows with a randomized component and check the amount
@@ -257,9 +259,9 @@ func TestConnCreateGetFlow(t *testing.T) {
 	for n, f := range flows {
 		_, err := c.Get(f)
 
-		opErr := errors.Cause(err)
-		require.IsType(t, &netlink.OpError{}, opErr)
-		require.EqualError(t, opErr.(*netlink.OpError).Err, unix.ENOENT.Error(), "get flow before creating")
+		opErr, ok := errors.Cause(err).(*netlink.OpError)
+		require.True(t, ok)
+		require.EqualError(t, unix.ENOENT, opErr.Err.Error(), "get flow before creating")
 
 		err = c.Create(f)
 		require.NoError(t, err, "creating flow", n)

--- a/flow_integration_test.go
+++ b/flow_integration_test.go
@@ -6,11 +6,11 @@ import (
 	"net"
 	"testing"
 
+	"github.com/mdlayher/netlink"
 	"github.com/pkg/errors"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
-
-	"github.com/stretchr/testify/assert"
 )
 
 // Create a given number of flows with a randomized component and check the amount
@@ -256,7 +256,10 @@ func TestConnCreateGetFlow(t *testing.T) {
 
 	for n, f := range flows {
 		_, err := c.Get(f)
-		require.EqualError(t, errors.Cause(err), unix.ENOENT.Error(), "get flow before creating")
+
+		opErr := errors.Cause(err)
+		require.IsType(t, &netlink.OpError{}, opErr)
+		require.EqualError(t, opErr.(*netlink.OpError).Err, unix.ENOENT.Error(), "get flow before creating")
 
 		err = c.Create(f)
 		require.NoError(t, err, "creating flow", n)


### PR DESCRIPTION
The netlink library has changed its APIs (name of constants) See issue: https://github.com/mdlayher/netlink/issues/123

This PR updates the constants in the conntrack library to follow the master.