### PR TITLE
Fix unmarshal when nf_conntrack_helper enabled

### DIFF
--- a/attribute_types.go
+++ b/attribute_types.go
@@ -449,8 +449,9 @@ func (ctr *Counter) unmarshal(attr netfilter.Attribute) error {
 		return errors.Wrap(errNotNested, opUnCounter)
 	}
 
-	// A Counter will always consist of packet and byte attributes
-	if len(attr.Children) != 2 {
+	// A Counter consists of packet and byte attributes but may have
+	// help attributes as well if nf_conntrack_helper enabled
+	if len(attr.Children) < 2 {
 		return fmt.Errorf(errExactChildren, 2, ctaCountersOrigReplyCat)
 	}
 
@@ -463,6 +464,9 @@ func (ctr *Counter) unmarshal(attr netfilter.Attribute) error {
 			ctr.Packets = iattr.Uint64()
 		case ctaCountersBytes:
 			ctr.Bytes = iattr.Uint64()
+		case counterType(ctaHelp):
+			// Ignore any helper children if nf_conntrack_helper is enabled
+			continue
 		default:
 			return fmt.Errorf(errAttributeChild, iattr.Type, ctaCountersOrigReplyCat)
 		}

--- a/attribute_types.go
+++ b/attribute_types.go
@@ -452,7 +452,7 @@ func (ctr *Counter) unmarshal(attr netfilter.Attribute) error {
 	// A Counter consists of packet and byte attributes but may have
 	// help attributes as well if nf_conntrack_helper enabled
 	if len(attr.Children) < 2 {
-		return fmt.Errorf(errExactChildren, 2, ctaCountersOrigReplyCat)
+		return errors.Wrap(errNeedChildren, opUnCounter)
 	}
 
 	// Set Direction to true if it's a reply counter
@@ -464,8 +464,8 @@ func (ctr *Counter) unmarshal(attr netfilter.Attribute) error {
 			ctr.Packets = iattr.Uint64()
 		case ctaCountersBytes:
 			ctr.Bytes = iattr.Uint64()
-		case counterType(ctaHelp):
-			// Ignore any helper children if nf_conntrack_helper is enabled
+		case ctaCountersPad:
+			// Ignore padding attributes that show up if nf_conntrack_helper is enabled.
 			continue
 		default:
 			return fmt.Errorf(errAttributeChild, iattr.Type, ctaCountersOrigReplyCat)

--- a/attribute_types_test.go
+++ b/attribute_types_test.go
@@ -460,7 +460,7 @@ func TestAttributeCounters(t *testing.T) {
 
 			assert.EqualError(t, ctr.unmarshal(nfaBadType), fmt.Sprintf(errAttributeWrongType, ctaUnspec, ctaCountersOrigReplyCat))
 			assert.EqualError(t, ctr.unmarshal(nfaNotNested), errors.Wrap(errNotNested, opUnCounter).Error())
-			assert.EqualError(t, ctr.unmarshal(nfaNestedNoChildren), fmt.Sprintf(errExactChildren, 2, ctaCountersOrigReplyCat))
+			assert.EqualError(t, ctr.unmarshal(nfaNestedNoChildren), errors.Wrap(errNeedChildren, opUnCounter).Error())
 
 			nfaCounter := netfilter.Attribute{
 				Type:   uint16(at),

--- a/attribute_types_test.go
+++ b/attribute_types_test.go
@@ -474,6 +474,10 @@ func TestAttributeCounters(t *testing.T) {
 						Type: uint16(ctaCountersPackets),
 						Data: make([]byte, 8),
 					},
+					{
+						Type: uint16(ctaCountersPad),
+						Data: make([]byte, 8),
+					},
 				},
 			}
 

--- a/enum.go
+++ b/enum.go
@@ -129,6 +129,9 @@ const (
 	ctaCountersUnspec  counterType = iota // CTA_COUNTERS_UNSPEC
 	ctaCountersPackets                    // CTA_COUNTERS_PACKETS
 	ctaCountersBytes                      // CTA_COUNTERS_BYTES
+	_                                     // CTA_COUNTERS32_PACKETS, old 32bit counters, unused
+	_                                     // CTA_COUNTERS32_BYTES, old 32bit counters, unused
+	ctaCountersPad                        // CTA_COUNTERS_PAD
 )
 
 // timestampType describes the type of timestamp in this container.


### PR DESCRIPTION
Enabling netfilter helpers via nf_conntrack_helper parameter of
the nf_conntrack module changes the format of the netlink messages
for conntrack flows, adding two ctaHelp attributes to the existing
ctaCountersPackets and ctaCountersBytes attributes when parsing
flow counters.

This commit will allow unmarshaling to complete without error
by ignoring any child attributes of type ctaHelp when decoding
ctaCountersOrig or ctaCountersReply.