### PR TITLE
Integration test updating flows using a single tuple (orig/reply)

### DIFF
--- a/flow.go
+++ b/flow.go
@@ -176,7 +176,8 @@ func (f *Flow) unmarshal(attrs []netfilter.Attribute) error {
 // marshal marshals a Flow object into a list of netfilter.Attributes.
 func (f Flow) marshal() ([]netfilter.Attribute, error) {
 
-	// Each connection sent to the kernel should have at least an original and reply tuple.
+	// Flow updates need one of TupleOrig or TupleReply,
+	// so we enforce having either of those.
 	if !f.TupleOrig.filled() && !f.TupleReply.filled() {
 		return nil, errNeedTuples
 	}

--- a/flow_integration_test.go
+++ b/flow_integration_test.go
@@ -212,7 +212,7 @@ func TestConnCreateUpdateFlow(t *testing.T) {
 	require.NoError(t, err, "creating flow")
 
 	// Increase the flow's timeout from 120 in NewFlow().
-	f.Timeout = 240
+	f.Timeout = 210
 
 	err = c.Update(f)
 	require.NoError(t, err, "updating flow")
@@ -220,8 +220,42 @@ func TestConnCreateUpdateFlow(t *testing.T) {
 	flows, err := c.Dump()
 	require.NoError(t, err, "dumping table")
 
-	if got := flows[0].Timeout; !(got > 120) {
-		t.Fatalf("unexpected updated flow:\n- want: > 120\n-  got: %d", got)
+	if got := flows[0].Timeout; !(got > 200) {
+		t.Fatalf("unexpected updated flow:\n- want: > 200\n-  got: %d", got)
+	}
+
+	// Update the flow using only the TupleReply.
+	// The kernel allows an existing flow to be updated
+	// using only the TupleReply.
+	fNoOrig := f
+	fNoOrig.TupleOrig = Tuple{}
+	fNoOrig.Timeout = 310
+
+	err = c.Update(fNoOrig)
+	require.NoError(t, err, "updating flow without TupleOrig")
+
+	flows, err = c.Dump()
+	require.NoError(t, err, "dumping table")
+
+	if got := flows[0].Timeout; !(got > 300) {
+		t.Fatalf("unexpected updated flow:\n- want: > 300\n-  got: %d", got)
+	}
+
+	// Update the flow using only the TupleOrig.
+	// The kernel allows an existing flow to be updated
+	// using only the TupleOrig.
+	fNoReply := f
+	fNoReply.TupleReply = Tuple{}
+	fNoReply.Timeout = 410
+
+	err = c.Update(fNoReply)
+	require.NoError(t, err, "updating flow without TupleReply")
+
+	flows, err = c.Dump()
+	require.NoError(t, err, "dumping table")
+
+	if got := flows[0].Timeout; !(got > 400) {
+		t.Fatalf("unexpected updated flow:\n- want: > 400\n-  got: %d", got)
 	}
 }
 

--- a/flow_test.go
+++ b/flow_test.go
@@ -464,7 +464,7 @@ func TestFlowMarshal(t *testing.T) {
 	_, err = Flow{TupleReply: flowIPPT}.marshal()
 	assert.NoError(t, err)
 
-	// Cannot marshal without orig and reply tuples empty.
+	// Cannot marshal with both orig and reply tuples empty.
 	_, err = Flow{}.marshal()
 	assert.EqualError(t, err, errNeedTuples.Error())
 


### PR DESCRIPTION
Closes https://github.com/ti-mo/conntrack/issues/11.

@dstiliadis 