### PR TITLE
conn: Add conntrack dump while zeroing all counters

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -94,7 +94,7 @@ func ExampleConn_dumpFilter() {
 	_ = c.Create(f2)
 
 	// Dump all records in the Conntrack table that match the filter's mark/mask.
-	df, err := c.DumpFilter(conntrack.Filter{Mark: 0xff00, Mask: 0xff00})
+	df, err := c.DumpFilter(conntrack.Filter{Mark: 0xff00, Mask: 0xff00}, nil)
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
Apart from `IPCTNL_MSG_CT_GET` there's also `IPCTNL_MSG_CT_GET_CTRZERO`
which zeroes all the accounting counters that netfilter maintains. This
includes bytes and packets for each flow.

In order to avoid breaking the pre-existing [Dump](https://github.com/ti-mo/conntrack/blob/39fd2b98b91c2db9536dd524a88c1ee6af133838/conn.go#L131) function, I've opted to create a separate one, just for my usecase. 

If there's anything I missed, I'd be happy to fix it.