### PR TITLE
event: correctly parse TCP DESTROY events on kernels 5.11 and later

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -6,7 +6,6 @@ linters-settings:
 
 linters:
   enable:
-    - goerr113
     - gofmt
     - goimports
     - govet

--- a/attribute_types.go
+++ b/attribute_types.go
@@ -135,9 +135,14 @@ type ProtoInfoTCP struct {
 
 // unmarshal unmarshals netlink attributes into a ProtoInfoTCP.
 func (tpi *ProtoInfoTCP) unmarshal(ad *netlink.AttributeDecoder) error {
-	// A ProtoInfoTCP has at least 3 members, TCP_STATE and TCP_FLAGS_ORIG/REPLY.
-	if ad.Len() < 3 {
-		return errNeedChildren
+	// Since 86d21fc74745 ("netfilter: ctnetlink: add timeout and protoinfo to
+	// destroy events"), ProtoInfoTCP is sent in conntrack events, where
+	// previously it was only present in dumps/queries.
+	//
+	// NEW and UPDATE events potentially contain all attributes, but DESTROY
+	// events only contain TCP_STATE. Expect at least one attribute here.
+	if ad.Len() == 0 {
+		return errNeedSingleChild
 	}
 
 	for ad.Next() {
@@ -193,7 +198,7 @@ type ProtoInfoDCCP struct {
 // unmarshal unmarshals netlink attributes into a ProtoInfoDCCP.
 func (dpi *ProtoInfoDCCP) unmarshal(ad *netlink.AttributeDecoder) error {
 	if ad.Len() == 0 {
-		return errNeedChildren
+		return errNeedSingleChild
 	}
 
 	for ad.Next() {
@@ -233,7 +238,7 @@ type ProtoInfoSCTP struct {
 // unmarshal unmarshals netlink attributes into a ProtoInfoSCTP.
 func (spi *ProtoInfoSCTP) unmarshal(ad *netlink.AttributeDecoder) error {
 	if ad.Len() == 0 {
-		return errNeedChildren
+		return errNeedSingleChild
 	}
 
 	for ad.Next() {

--- a/attribute_types_test.go
+++ b/attribute_types_test.go
@@ -224,7 +224,7 @@ func TestProtoInfoTypeString(t *testing.T) {
 
 func TestAttributeProtoInfoTCP(t *testing.T) {
 	var pit ProtoInfoTCP
-	assert.ErrorIs(t, pit.unmarshal(adEmpty), errNeedChildren)
+	assert.ErrorIs(t, pit.unmarshal(adEmpty), errNeedSingleChild)
 
 	ad := adThreeUnknown
 	assert.ErrorIs(t, pit.unmarshal(&ad), errUnknownAttribute)
@@ -260,7 +260,7 @@ func TestAttributeProtoInfoTCP(t *testing.T) {
 
 func TestAttributeProtoInfoDCCP(t *testing.T) {
 	var pid ProtoInfoDCCP
-	assert.ErrorIs(t, pid.unmarshal(adEmpty), errNeedChildren)
+	assert.ErrorIs(t, pid.unmarshal(adEmpty), errNeedSingleChild)
 
 	ad := adThreeUnknown
 	assert.ErrorIs(t, pid.unmarshal(&ad), errUnknownAttribute)
@@ -288,7 +288,7 @@ func TestAttributeProtoInfoDCCP(t *testing.T) {
 
 func TestAttributeProtoInfoSCTP(t *testing.T) {
 	var pid ProtoInfoSCTP
-	assert.ErrorIs(t, pid.unmarshal(adEmpty), errNeedChildren)
+	assert.ErrorIs(t, pid.unmarshal(adEmpty), errNeedSingleChild)
 
 	ad := adOneUnknown
 	assert.ErrorIs(t, pid.unmarshal(&ad), errUnknownAttribute)

--- a/conn.go
+++ b/conn.go
@@ -419,7 +419,6 @@ func (c *Conn) Get(f Flow) (Flow, error) {
 // SynProxy, Labels. All other attributes are immutable past the point of creation.
 // See the ctnetlink_change_conntrack() kernel function for exact behaviour.
 func (c *Conn) Update(f Flow) error {
-
 	// Kernel rejects updates with a master tuple set
 	if f.TupleMaster.filled() {
 		return errUpdateMaster
@@ -459,7 +458,6 @@ func (c *Conn) Update(f Flow) error {
 // based on the original and reply tuple. When the Flow's ID field is filled, it must match the
 // ID on the connection returned from the tuple lookup, or the delete will fail.
 func (c *Conn) Delete(f Flow) error {
-
 	attrs, err := f.marshal()
 	if err != nil {
 		return err

--- a/flow_integration_test.go
+++ b/flow_integration_test.go
@@ -194,7 +194,6 @@ func TestConnCreateDeleteFlows(t *testing.T) {
 
 // Creates a flow, updates it and checks the result.
 func TestConnCreateUpdateFlow(t *testing.T) {
-
 	c, _, err := makeNSConn()
 	require.NoError(t, err)
 


### PR DESCRIPTION
Closes https://github.com/ti-mo/conntrack/issues/28, fixes torvalds/linux@86d21fc74745.