### PR TITLE
Use netip.Addr instead of net.IP

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -3,7 +3,7 @@ package conntrack_test
 import (
 	"fmt"
 	"log"
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/mdlayher/netlink"
@@ -34,8 +34,8 @@ func ExampleConn_createUpdateFlow() {
 	// Set up a new Flow object using a given set of attributes.
 	f := conntrack.NewFlow(
 		17, 0,
-		net.ParseIP("2a00:1450:400e:804::200e"),
-		net.ParseIP("2a00:1450:400e:804::200f"),
+		netip.MustParseAddr("2a00:1450:400e:804::200e"),
+		netip.MustParseAddr("2a00:1450:400e:804::200f"),
 		1234, 80, 120, 0,
 	)
 
@@ -72,12 +72,12 @@ func ExampleConn_dumpFilter() {
 	}
 
 	f1 := conntrack.NewFlow(
-		6, 0, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8),
+		6, 0, netip.MustParseAddr("1.2.3.4"), netip.MustParseAddr("5.6.7.8"),
 		1234, 80, 120, 0x00ff, // Set a connection mark
 	)
 
 	f2 := conntrack.NewFlow(
-		17, 0, net.ParseIP("2a00:1450:400e:804::200e"), net.ParseIP("2a00:1450:400e:804::200f"),
+		17, 0, netip.MustParseAddr("2a00:1450:400e:804::200e"), netip.MustParseAddr("2a00:1450:400e:804::200f"),
 		1234, 80, 120, 0xff00, // Set a connection mark
 	)
 
@@ -116,12 +116,12 @@ func ExampleConn_flushFilter() {
 	}
 
 	f1 := conntrack.NewFlow(
-		6, 0, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8),
+		6, 0, netip.MustParseAddr("1.2.3.4"), netip.MustParseAddr("5.6.7.8"),
 		1234, 80, 120, 0x00ff, // Set a connection mark
 	)
 
 	f2 := conntrack.NewFlow(
-		17, 0, net.ParseIP("2a00:1450:400e:804::200e"), net.ParseIP("2a00:1450:400e:804::200f"),
+		17, 0, netip.MustParseAddr("2a00:1450:400e:804::200e"), netip.MustParseAddr("2a00:1450:400e:804::200f"),
 		1234, 80, 120, 0xff00, // Set a connection mark
 	)
 
@@ -155,7 +155,7 @@ func ExampleConn_delete() {
 	}
 
 	f := conntrack.NewFlow(
-		6, 0, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8),
+		6, 0, netip.MustParseAddr("1.2.3.4"), netip.MustParseAddr("5.6.7.8"),
 		1234, 80, 120, 0,
 	)
 

--- a/event_integration_test.go
+++ b/event_integration_test.go
@@ -3,7 +3,7 @@
 package conntrack
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/mdlayher/netlink"
@@ -43,7 +43,7 @@ func TestConnListen(t *testing.T) {
 
 	var warn bool
 
-	ip := net.ParseIP("::f00")
+	ip := netip.MustParseAddr("::f00")
 	for _, proto := range []uint8{unix.IPPROTO_TCP, unix.IPPROTO_UDP, unix.IPPROTO_DCCP, unix.IPPROTO_SCTP} {
 		// Create the Flow.
 		f := NewFlow(

--- a/expect_integration_test.go
+++ b/expect_integration_test.go
@@ -3,7 +3,7 @@
 package conntrack
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -27,7 +27,7 @@ func TestConnCreateExpect(t *testing.T) {
 	c, _, err := makeNSConn()
 	require.NoError(t, err)
 
-	f := NewFlow(6, 0, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8), 42000, 21, 120, 0)
+	f := NewFlow(6, 0, netip.MustParseAddr("1.2.3.4"), netip.MustParseAddr("5.6.7.8"), 42000, 21, 120, 0)
 
 	err = c.Create(f)
 	require.NoError(t, err, "unexpected error creating flow", f)
@@ -37,8 +37,8 @@ func TestConnCreateExpect(t *testing.T) {
 		TupleMaster: f.TupleOrig,
 		Tuple: Tuple{
 			IP: IPTuple{
-				SourceAddress:      net.IPv4(1, 2, 3, 4),
-				DestinationAddress: net.IPv4(5, 6, 7, 8),
+				SourceAddress:      netip.MustParseAddr("1.2.3.4"),
+				DestinationAddress: netip.MustParseAddr("5.6.7.8"),
 			},
 			Proto: ProtoTuple{
 				Protocol:        6,
@@ -48,8 +48,8 @@ func TestConnCreateExpect(t *testing.T) {
 		},
 		Mask: Tuple{
 			IP: IPTuple{
-				SourceAddress:      net.IPv4(255, 255, 255, 255),
-				DestinationAddress: net.IPv4(255, 255, 255, 255),
+				SourceAddress:      netip.MustParseAddr("255.255.255.255"),
+				DestinationAddress: netip.MustParseAddr("255.255.255.255"),
 			},
 			Proto: ProtoTuple{
 				Protocol:        6,

--- a/filter_test.go
+++ b/filter_test.go
@@ -3,9 +3,9 @@ package conntrack
 import (
 	"testing"
 
-	"github.com/ti-mo/netfilter"
+	"github.com/stretchr/testify/assert"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/ti-mo/netfilter"
 )
 
 func TestFilterMarshal(t *testing.T) {
@@ -22,7 +22,5 @@ func TestFilterMarshal(t *testing.T) {
 		},
 	}
 
-	if diff := cmp.Diff(fm, f.marshal()); diff != "" {
-		t.Fatalf("unexpected Filter marshal (-want +got):\n%s", diff)
-	}
+	assert.Equal(t, fm, f.marshal(), "unexpected Filter marshal")
 }

--- a/flow.go
+++ b/flow.go
@@ -2,7 +2,7 @@ package conntrack
 
 import (
 	"fmt"
-	"net"
+	"net/netip"
 
 	"github.com/mdlayher/netlink"
 	"github.com/ti-mo/netfilter"
@@ -44,7 +44,7 @@ type Flow struct {
 // source and destination addresses. srcPort and dstPort are the source and
 // destination ports. timeout is the non-zero time-to-live of a connection in
 // seconds.
-func NewFlow(proto uint8, status StatusFlag, srcAddr, destAddr net.IP,
+func NewFlow(proto uint8, status StatusFlag, srcAddr, destAddr netip.Addr,
 	srcPort, destPort uint16, timeout, mark uint32) Flow {
 
 	var f Flow

--- a/flow_integration_test.go
+++ b/flow_integration_test.go
@@ -3,7 +3,7 @@
 package conntrack
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"golang.org/x/sys/unix"
@@ -35,7 +35,7 @@ func TestConnCreateFlows(t *testing.T) {
 
 	// Create IPv4 flows
 	for i := 1; i <= numFlows; i++ {
-		f = NewFlow(6, 0, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8), 1234, uint16(i), 120, 0)
+		f = NewFlow(6, 0, netip.MustParseAddr("1.2.3.4"), netip.MustParseAddr("5.6.7.8"), 1234, uint16(i), 120, 0)
 
 		err = c.Create(f)
 		require.NoError(t, err, "creating IPv4 flow", i)
@@ -45,8 +45,8 @@ func TestConnCreateFlows(t *testing.T) {
 	for i := 1; i <= numFlows; i++ {
 		err = c.Create(NewFlow(
 			17, 0,
-			net.ParseIP("2a00:1450:400e:804::200e"),
-			net.ParseIP("2a00:1450:400e:804::200f"),
+			netip.MustParseAddr("2a00:1450:400e:804::200e"),
+			netip.MustParseAddr("2a00:1450:400e:804::200f"),
 			1234, uint16(i), 120, 0,
 		))
 		require.NoError(t, err, "creating IPv6 flow", i)
@@ -81,8 +81,8 @@ func TestConnFlush(t *testing.T) {
 	// Create IPv4 flow
 	err = c.Create(NewFlow(
 		6, 0,
-		net.IPv4(1, 2, 3, 4),
-		net.IPv4(5, 6, 7, 8),
+		netip.MustParseAddr("1.2.3.4"),
+		netip.MustParseAddr("5.6.7.8"),
 		1234, 80, 120, 0,
 	))
 	require.NoError(t, err, "creating IPv4 flow")
@@ -90,8 +90,8 @@ func TestConnFlush(t *testing.T) {
 	// Create IPv6 flow
 	err = c.Create(NewFlow(
 		17, 0,
-		net.ParseIP("2a00:1450:400e:804::200e"),
-		net.ParseIP("2a00:1450:400e:804::200f"),
+		netip.MustParseAddr("2a00:1450:400e:804::200e"),
+		netip.MustParseAddr("2a00:1450:400e:804::200f"),
 		1234, 80, 120, 0,
 	))
 	require.NoError(t, err, "creating IPv6 flow")
@@ -130,8 +130,8 @@ func TestConnFlushFilter(t *testing.T) {
 	// Create IPv4 flow
 	err = c.Create(NewFlow(
 		6, 0,
-		net.IPv4(1, 2, 3, 4),
-		net.IPv4(5, 6, 7, 8),
+		netip.MustParseAddr("1.2.3.4"),
+		netip.MustParseAddr("5.6.7.8"),
 		1234, 80, 120, 0,
 	))
 	require.NoError(t, err, "creating IPv4 flow")
@@ -139,8 +139,8 @@ func TestConnFlushFilter(t *testing.T) {
 	// Create IPv6 flow with mark
 	err = c.Create(NewFlow(
 		17, 0,
-		net.ParseIP("2a00:1450:400e:804::200e"),
-		net.ParseIP("2a00:1450:400e:804::200f"),
+		netip.MustParseAddr("2a00:1450:400e:804::200e"),
+		netip.MustParseAddr("2a00:1450:400e:804::200f"),
 		1234, 80, 120, 0xff00,
 	))
 	require.NoError(t, err, "creating IPv6 flow")
@@ -174,8 +174,8 @@ func TestConnCreateDeleteFlows(t *testing.T) {
 	for i := 1; i <= numFlows; i++ {
 		f = NewFlow(
 			17, 0,
-			net.ParseIP("2a00:1450:400e:804::223e"),
-			net.ParseIP("2a00:1450:400e:804::223f"),
+			netip.MustParseAddr("2a00:1450:400e:804::223e"),
+			netip.MustParseAddr("2a00:1450:400e:804::223f"),
 			1234, uint16(i), 120, 0,
 		)
 
@@ -199,8 +199,8 @@ func TestConnCreateUpdateFlow(t *testing.T) {
 
 	f := NewFlow(
 		17, 0,
-		net.ParseIP("1.2.3.4"),
-		net.ParseIP("5.6.7.8"),
+		netip.MustParseAddr("1.2.3.4"),
+		netip.MustParseAddr("5.6.7.8"),
 		1234, 5678, 120, 0,
 	)
 
@@ -262,8 +262,8 @@ func TestConnUpdateError(t *testing.T) {
 
 	f := NewFlow(
 		17, 0,
-		net.ParseIP("1.2.3.4"),
-		net.ParseIP("5.6.7.8"),
+		netip.MustParseAddr("1.2.3.4"),
+		netip.MustParseAddr("5.6.7.8"),
 		1234, 5678, 120, 0,
 	)
 
@@ -280,10 +280,10 @@ func TestConnCreateGetFlow(t *testing.T) {
 	require.NoError(t, err)
 
 	flows := map[string]Flow{
-		"v4m1": NewFlow(17, 0, net.ParseIP("1.2.3.4"), net.ParseIP("5.6.7.8"), 1234, 5678, 120, 0),
-		"v4m2": NewFlow(17, 0, net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2"), 24000, 80, 120, 0),
-		"v6m1": NewFlow(17, 0, net.ParseIP("2a12:1234:200f:600::200a"), net.ParseIP("2a12:1234:200f:600::200b"), 6554, 53, 120, 0),
-		"v6m2": NewFlow(17, 0, net.ParseIP("900d:f00d:24::7"), net.ParseIP("baad:beef:b00::b00"), 1323, 22, 120, 0),
+		"v4m1": NewFlow(17, 0, netip.MustParseAddr("1.2.3.4"), netip.MustParseAddr("5.6.7.8"), 1234, 5678, 120, 0),
+		"v4m2": NewFlow(17, 0, netip.MustParseAddr("10.0.0.1"), netip.MustParseAddr("10.0.0.2"), 24000, 80, 120, 0),
+		"v6m1": NewFlow(17, 0, netip.MustParseAddr("2a12:1234:200f:600::200a"), netip.MustParseAddr("2a12:1234:200f:600::200b"), 6554, 53, 120, 0),
+		"v6m2": NewFlow(17, 0, netip.MustParseAddr("900d:f00d:24::7"), netip.MustParseAddr("baad:beef:b00::b00"), 1323, 22, 120, 0),
 	}
 
 	for n, f := range flows {
@@ -306,7 +306,7 @@ func TestDumpZero(t *testing.T) {
 	c, _, err := makeNSConn()
 	require.NoError(t, err)
 
-	f := NewFlow(17, 0, net.ParseIP("1.2.3.4"), net.ParseIP("5.6.7.8"), 1234, 5678, 120, 0xff000000)
+	f := NewFlow(17, 0, netip.MustParseAddr("1.2.3.4"), netip.MustParseAddr("5.6.7.8"), 1234, 5678, 120, 0xff000000)
 
 	f.CountersOrig.Bytes = 1337
 	f.CountersReply.Bytes = 9001
@@ -332,10 +332,10 @@ func TestConnDumpFilter(t *testing.T) {
 	require.NoError(t, err)
 
 	flows := map[string]Flow{
-		"v4m1": NewFlow(17, 0, net.ParseIP("1.2.3.4"), net.ParseIP("5.6.7.8"), 1234, 5678, 120, 0xff000000),
-		"v4m2": NewFlow(17, 0, net.ParseIP("10.0.0.1"), net.ParseIP("10.0.0.2"), 24000, 80, 120, 0x00ff0000),
-		"v6m1": NewFlow(17, 0, net.ParseIP("2a12:1234:200f:600::200a"), net.ParseIP("2a12:1234:200f:600::200b"), 6554, 53, 120, 0x0000ff00),
-		"v6m2": NewFlow(17, 0, net.ParseIP("900d:f00d:24::7"), net.ParseIP("baad:beef:b00::b00"), 1323, 22, 120, 0x000000ff),
+		"v4m1": NewFlow(17, 0, netip.MustParseAddr("1.2.3.4"), netip.MustParseAddr("5.6.7.8"), 1234, 5678, 120, 0xff000000),
+		"v4m2": NewFlow(17, 0, netip.MustParseAddr("10.0.0.1"), netip.MustParseAddr("10.0.0.2"), 24000, 80, 120, 0x00ff0000),
+		"v6m1": NewFlow(17, 0, netip.MustParseAddr("2a12:1234:200f:600::200a"), netip.MustParseAddr("2a12:1234:200f:600::200b"), 6554, 53, 120, 0x0000ff00),
+		"v6m2": NewFlow(17, 0, netip.MustParseAddr("900d:f00d:24::7"), netip.MustParseAddr("baad:beef:b00::b00"), 1323, 22, 120, 0x000000ff),
 	}
 
 	// Expect empty result from empty table dump
@@ -372,7 +372,7 @@ func BenchmarkCreateDeleteFlow(b *testing.B) {
 		b.Fatal(err)
 	}
 
-	f := NewFlow(6, 0, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8), 1234, 80, 120, 0)
+	f := NewFlow(6, 0, netip.MustParseAddr("1.2.3.4"), netip.MustParseAddr("5.6.7.8"), 1234, 80, 120, 0)
 
 	for n := 0; n < b.N; n++ {
 		err = c.Create(f)

--- a/flow_test.go
+++ b/flow_test.go
@@ -571,9 +571,9 @@ func BenchmarkFlowUnmarshal(b *testing.B) {
 
 	for n := 0; n < b.N; n++ {
 		// Make a new copy of the AD to avoid reinstantiation.
-		iad := ad
+		iad := *ad
 
 		var f Flow
-		_ = f.unmarshal(iad)
+		_ = f.unmarshal(&iad)
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/ti-mo/conntrack
 go 1.20
 
 require (
-	github.com/google/go-cmp v0.6.0
 	github.com/mdlayher/netlink v1.7.2
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.8.4
@@ -14,6 +13,7 @@ require (
 
 require (
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/google/go-cmp v0.6.0 // indirect
 	github.com/josharian/native v1.1.0 // indirect
 	github.com/mdlayher/socket v0.4.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect

--- a/stats_integration_test.go
+++ b/stats_integration_test.go
@@ -3,7 +3,7 @@
 package conntrack
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -61,7 +61,7 @@ func TestConnStatsGlobal(t *testing.T) {
 
 	// Create IPv4 flows
 	for i := 1; i <= numFlows; i++ {
-		f = NewFlow(6, 0, net.IPv4(1, 2, 3, 4), net.IPv4(5, 6, 7, 8), 1234, uint16(i), 120, 0)
+		f = NewFlow(6, 0, netip.MustParseAddr("1.2.3.4"), netip.MustParseAddr("5.6.7.8"), 1234, uint16(i), 120, 0)
 
 		err = c.Create(f)
 		require.NoError(t, err, "creating IPv4 flow", i)
@@ -71,8 +71,8 @@ func TestConnStatsGlobal(t *testing.T) {
 	for i := 1; i <= numFlows; i++ {
 		err = c.Create(NewFlow(
 			17, 0,
-			net.ParseIP("2a00:1450:400e:804::200e"),
-			net.ParseIP("2a00:1450:400e:804::200f"),
+			netip.MustParseAddr("2a00:1450:400e:804::200e"),
+			netip.MustParseAddr("2a00:1450:400e:804::200f"),
 			1234, uint16(i), 120, 0,
 		))
 		require.NoError(t, err, "creating IPv6 flow", i)

--- a/stats_test.go
+++ b/stats_test.go
@@ -3,7 +3,7 @@ package conntrack
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
+	"github.com/stretchr/testify/assert"
 
 	"github.com/ti-mo/netfilter"
 )
@@ -67,10 +67,7 @@ func TestStatsUnmarshal(t *testing.T) {
 
 	var s Stats
 	s.unmarshal(nfa)
-
-	if diff := cmp.Diff(want, s); diff != "" {
-		t.Fatalf("unexpected unmarshal (-want +got):\n%s", diff)
-	}
+	assert.Equal(t, want, s, "unexpected unmarshal")
 }
 
 func TestStatsExpectUnmarshal(t *testing.T) {
@@ -98,10 +95,7 @@ func TestStatsExpectUnmarshal(t *testing.T) {
 
 	var se StatsExpect
 	se.unmarshal(nfa)
-
-	if diff := cmp.Diff(want, se); diff != "" {
-		t.Fatalf("unexpected unmarshal (-want +got):\n%s", diff)
-	}
+	assert.Equal(t, want, se, "unexpected unmarshal")
 }
 
 func TestStatsGlobalUnmarshal(t *testing.T) {
@@ -124,8 +118,5 @@ func TestStatsGlobalUnmarshal(t *testing.T) {
 
 	var sg StatsGlobal
 	sg.unmarshal(nfa)
-
-	if diff := cmp.Diff(want, sg); diff != "" {
-		t.Fatalf("unexpected unmarshal (-want +got):\n%s", diff)
-	}
+	assert.Equal(t, want, sg, "unexpected unmarshal")
 }

--- a/status_test.go
+++ b/status_test.go
@@ -3,7 +3,6 @@ package conntrack
 import (
 	"testing"
 
-	"github.com/google/go-cmp/cmp"
 	"github.com/mdlayher/netlink"
 	"github.com/mdlayher/netlink/nlenc"
 	"github.com/mdlayher/netlink/nltest"
@@ -72,15 +71,10 @@ func TestStatusMarshalTwoWay(t *testing.T) {
 				return
 			}
 
-			if diff := cmp.Diff(tt.status.Value, s.Value); diff != "" {
-				t.Fatalf("unexpected unmarshal (-want +got):\n%s", diff)
-			}
+			require.Equal(t, tt.status.Value, s.Value, "unexpected unmarshal")
 
 			ms := s.marshal()
-			require.NoError(t, err, "error during marshal:", s)
-			if diff := cmp.Diff(nfa, ms); diff != "" {
-				t.Fatalf("unexpected marshal (-want +got):\n%s", diff)
-			}
+			assert.Equal(t, nfa, ms, "unexpected marshal")
 		})
 	}
 }

--- a/string_test.go
+++ b/string_test.go
@@ -1,7 +1,7 @@
 package conntrack
 
 import (
-	"net"
+	"net/netip"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -21,11 +21,10 @@ func TestProtoLookup(t *testing.T) {
 }
 
 func TestEventString(t *testing.T) {
-
 	tpl := Tuple{
 		IP: IPTuple{
-			SourceAddress:      net.IPv4(1, 2, 3, 4),
-			DestinationAddress: net.ParseIP("fe80::1"),
+			SourceAddress:      netip.MustParseAddr("1.2.3.4"),
+			DestinationAddress: netip.MustParseAddr("fe80::1"),
 		},
 		Proto: ProtoTuple{
 			SourcePort:      54321,


### PR DESCRIPTION
Using the net/netip package instead of the net package can help reduce
the memory footprint of the library and help reduce the number of
heap allocations.

This is a breaking change for consumers for the libray as exported types
are updated to use fields of type netip.Addr instead of net.IP.

We also include additional benchmarks to better understand the impact
of this change.

Fixes #35