### PR TITLE
Make Event.Unmarshal method public.

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,9 +1,3 @@
-linters-settings:
-  staticcheck:
-    go: "1.19"
-  unused:
-    go: "1.19"
-
 linters:
   enable:
     - gofmt

--- a/conn.go
+++ b/conn.go
@@ -154,7 +154,7 @@ func (c *Conn) eventWorker(workerID uint8, evChan chan<- Event, errChan chan<- e
 
 		// Decode event and send on channel
 		ev = *new(Event)
-		err := ev.unmarshal(recv[0])
+		err := ev.Unmarshal(recv[0])
 		if err != nil {
 			errChan <- err
 			return

--- a/event.go
+++ b/event.go
@@ -64,8 +64,8 @@ func (et *eventType) unmarshal(h netfilter.Header) error {
 	return nil
 }
 
-// unmarshal unmarshals a Netlink message into an Event structure.
-func (e *Event) unmarshal(nlmsg netlink.Message) error {
+// Unmarshal unmarshals a Netlink message into an Event structure.
+func (e *Event) Unmarshal(nlmsg netlink.Message) error {
 	// Make sure we don't re-use an Event structure
 	if e.Expect != nil || e.Flow != nil {
 		return errReusedEvent

--- a/event_test.go
+++ b/event_test.go
@@ -135,7 +135,7 @@ func TestEventUnmarshal(t *testing.T) {
 			require.NoError(t, err)
 
 			var e Event
-			assert.NoError(t, e.unmarshal(nlm))
+			assert.NoError(t, e.Unmarshal(nlm))
 			assert.Equal(t, tt.e, e, "unexpected unmarshal")
 		})
 	}
@@ -144,17 +144,17 @@ func TestEventUnmarshal(t *testing.T) {
 func TestEventUnmarshalError(t *testing.T) {
 	// Unmarshal into event with existing Flow
 	eventExistingFlow := Event{Flow: &Flow{}}
-	assert.ErrorIs(t, eventExistingFlow.unmarshal(netlink.Message{}), errReusedEvent)
+	assert.ErrorIs(t, eventExistingFlow.Unmarshal(netlink.Message{}), errReusedEvent)
 
 	// EventType unmarshal error, blank SubsystemID
 	var emptyEvent Event
-	assert.ErrorIs(t, emptyEvent.unmarshal(netlink.Message{
+	assert.ErrorIs(t, emptyEvent.Unmarshal(netlink.Message{
 		Header: netlink.Header{},
 		Data:   []byte{1, 2, 3, 4},
 	}), errNotConntrack)
 
 	// Cause a random error during Flow unmarshal
-	assert.ErrorIs(t, emptyEvent.unmarshal(netlink.Message{
+	assert.ErrorIs(t, emptyEvent.Unmarshal(netlink.Message{
 		Header: netlink.Header{Type: netlink.HeaderType(netfilter.NFSubsysCTNetlink) << 8},
 		Data: []byte{
 			1, 2, 3, 4, // random 4-byte nfgenmsg

--- a/string.go
+++ b/string.go
@@ -67,9 +67,7 @@ func (s Status) String() string {
 }
 
 func (e Event) String() string {
-
 	if e.Flow != nil {
-
 		// Status flag
 		status := ""
 		if !e.Flow.Status.SeenReply() {
@@ -117,17 +115,15 @@ func (e Event) String() string {
 			e.Flow.Zone,
 			acct, labels, mark,
 			seqadjo, seqadjr, secctx)
+	}
 
-	} else if e.Expect != nil {
-
+	if e.Expect != nil {
 		return fmt.Sprintf("[%s] Timeout: %d, Master: %s, Tuple: %s, Mask: %s, Zone: %d, Helper: '%s', Class: %#x",
 			e.Type, e.Expect.Timeout,
 			e.Expect.TupleMaster, e.Expect.Tuple, e.Expect.Mask,
 			e.Expect.Zone, e.Expect.HelpName, e.Expect.Class,
 		)
-
-	} else {
-		return fmt.Sprintf("[%s] <Empty Event>", e.Type)
 	}
 
+	return fmt.Sprintf("[%s] <Empty Event>", e.Type)
 }


### PR DESCRIPTION
I am using a different receive method from what this package provides, but my code would really benefit from the parsing method being public.