### PR TITLE
Add to wait group prior to starting event worker

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -107,6 +107,7 @@ func (c *Conn) Listen(evChan chan<- Event, numWorkers uint8, groups []netfilter.
 
 	// Start numWorkers amount of worker goroutines
 	for id := uint8(0); id < numWorkers; id++ {
+		c.workers.Add(1)
 		go c.eventWorker(id, evChan, errChan)
 	}
 
@@ -119,7 +120,6 @@ func (c *Conn) eventWorker(workerID uint8, evChan chan<- Event, errChan chan<- e
 	var recv []netlink.Message
 	var ev Event
 
-	c.workers.Add(1)
 	defer c.workers.Done()
 
 	for {


### PR DESCRIPTION
When calling Listen and Close in quick succession repeatedly, the previous code would occasionally panic with:

sync: WaitGroup is reused before previous Wait has returned

From the Go doc on WaitGroup.Add:

Typically this means the calls to Add should execute before the statement creating the goroutine or other event to be waited for.

By moving the call to Add just before starting the event worker goroutine, this commit ensures calls to Wait will not panic under load.