### PR TITLE
Fix Conn.Get to correctly set IP family for partial IPv6 filters

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -382,7 +382,7 @@ func (c *Conn) Get(f Flow) (Flow, error) {
 	}
 
 	pf := netfilter.ProtoIPv4
-	if f.TupleOrig.IP.IsIPv6() && f.TupleReply.IP.IsIPv6() {
+	if f.TupleOrig.IP.IsIPv6() || f.TupleReply.IP.IsIPv6() {
 		pf = netfilter.ProtoIPv6
 	}
 

--- a/flow_integration_test.go
+++ b/flow_integration_test.go
@@ -298,6 +298,22 @@ func TestConnCreateGetFlow(t *testing.T) {
 
 		assert.Equal(t, qflow.TupleOrig.IP.SourceAddress, f.TupleOrig.IP.SourceAddress)
 		assert.Equal(t, qflow.TupleOrig.IP.DestinationAddress, f.TupleOrig.IP.DestinationAddress)
+
+		fOrig := f
+		fOrig.TupleReply = Tuple{}
+		qflow, err = c.Get(fOrig)
+		require.NoError(t, err, "get flow by TupleOrig", n)
+
+		assert.Equal(t, qflow.TupleReply.IP.SourceAddress, f.TupleReply.IP.SourceAddress)
+		assert.Equal(t, qflow.TupleReply.IP.DestinationAddress, f.TupleReply.IP.DestinationAddress)
+
+		fReply := f
+		fReply.TupleOrig = Tuple{}
+		qflow, err = c.Get(fReply)
+		require.NoError(t, err, "get flow by TupleReply", n)
+
+		assert.Equal(t, qflow.TupleOrig.IP.SourceAddress, f.TupleOrig.IP.SourceAddress)
+		assert.Equal(t, qflow.TupleOrig.IP.DestinationAddress, f.TupleOrig.IP.DestinationAddress)
 	}
 }
 


### PR DESCRIPTION
`Conn.Get` supports filters with only one of `TupleOrig` or `TupleReply` defined. However, when using such a partial filter with IPv6 addresses, the function failed to set the correct IP family (`ProtoIPv6`) in the netfilter header, resulting in the error:
```
netfilter query: netlink receive: invalid argument
```
This change updates the condition to set the protocol family to IPv6 if either `TupleOrig` or `TupleReply` uses an IPv6 address.