### PR TITLE
Update module name to github.com/ClickHouse/conntrack

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/ti-mo/conntrack"
+	"github.com/ClickHouse/conntrack"
 	"github.com/ti-mo/netfilter"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/ti-mo/conntrack
+module github.com/ClickHouse/conntrack
 
 go 1.23.0
 


### PR DESCRIPTION
- Change module declaration from github.com/ti-mo/conntrack to github.com/ClickHouse/conntrack
- Update internal import in conn_test.go to use new module name
- This enables using the ClickHouse fork with proper module naming