### PR TITLE
flow: remove surrounding struct from StatusFlag, rename to Status

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -93,7 +93,7 @@ func (f *filter) MarkMask(mask uint32) Filter {
 }
 
 func (f *filter) Status(status Status) Filter {
-	f.f[ctaStatus] = netfilter.Uint32Bytes(uint32(status.Value))
+	f.f[ctaStatus] = netfilter.Uint32Bytes(uint32(status))
 	return f
 }
 

--- a/filter_test.go
+++ b/filter_test.go
@@ -13,7 +13,7 @@ func TestFilterMarshal(t *testing.T) {
 	f := NewFilter().
 		Mark(0xf0000000).MarkMask(0x0000000f).
 		Zone(42).
-		Status(Status{StatusDying}).StatusMask(0xdeadbeef)
+		Status(StatusDying).StatusMask(0xdeadbeef)
 
 	want := []netfilter.Attribute{
 		{

--- a/flow.go
+++ b/flow.go
@@ -44,12 +44,12 @@ type Flow struct {
 // source and destination addresses. srcPort and dstPort are the source and
 // destination ports. timeout is the non-zero time-to-live of a connection in
 // seconds.
-func NewFlow(proto uint8, status StatusFlag, srcAddr, destAddr netip.Addr,
+func NewFlow(proto uint8, status Status, srcAddr, destAddr netip.Addr,
 	srcPort, destPort uint16, timeout, mark uint32) Flow {
 
 	var f Flow
 
-	f.Status.Value = status
+	f.Status = status
 
 	f.Timeout = timeout
 	f.Mark = mark
@@ -107,7 +107,7 @@ func (f *Flow) unmarshal(ad *netlink.AttributeDecoder) error {
 		// CTA_STATUS is a bitfield of the state of the connection
 		// (eg. if packets are seen in both directions, etc.)
 		case ctaStatus:
-			f.Status.Value = StatusFlag(ad.Uint32())
+			f.Status = Status(ad.Uint32())
 		}
 	}
 
@@ -211,7 +211,7 @@ func (f Flow) marshal() ([]netfilter.Attribute, error) {
 		attrs = append(attrs, a)
 	}
 
-	if f.Status.Value != 0 {
+	if f.Status != 0 {
 		attrs = append(attrs, f.Status.marshal())
 	}
 

--- a/flow_integration_test.go
+++ b/flow_integration_test.go
@@ -478,16 +478,16 @@ func TestStatusFilter(t *testing.T) {
 	require.NoError(t, err)
 	assert.Len(t, flows, 2, "expected 2 flows in total")
 
-	flows, err = c.DumpFilter(NewFilter().Status(Status{StatusConfirmed}), nil)
+	flows, err = c.DumpFilter(NewFilter().Status(StatusConfirmed), nil)
 	require.NoError(t, err)
 	assert.Len(t, flows, 2)
 
-	flows, err = c.DumpFilter(NewFilter().Status(Status{StatusDying}), nil)
+	flows, err = c.DumpFilter(NewFilter().Status(StatusDying), nil)
 	require.NoError(t, err)
 	assert.Len(t, flows, 0)
 
 	// This filter can never return anything since status and mask don't overlap.
-	flows, err = c.DumpFilter(NewFilter().Status(Status{StatusConfirmed}).StatusMask(0x1), nil)
+	flows, err = c.DumpFilter(NewFilter().Status(StatusConfirmed).StatusMask(0x1), nil)
 	require.NoError(t, err)
 	assert.Len(t, flows, 0)
 }

--- a/flow_test.go
+++ b/flow_test.go
@@ -148,7 +148,7 @@ var (
 					Data: []byte{0xff, 0x00, 0xff, 0x00},
 				},
 			},
-			flow: Flow{Status: Status{Value: 0xff00ff00}},
+			flow: Flow{Status: 0xff00ff00},
 		},
 		{
 			name: "protoinfo attribute w/ tcp info",
@@ -420,7 +420,7 @@ func TestFlowMarshal(t *testing.T) {
 	attrs, err := Flow{
 		TupleOrig: flowIPPT, TupleReply: flowIPPT, TupleMaster: flowIPPT,
 		ProtoInfo: ProtoInfo{TCP: &ProtoInfoTCP{State: 42}},
-		Timeout:   123, Status: Status{Value: 1234}, Mark: 0x1234, Zone: 2,
+		Timeout:   123, Status: 1234, Mark: 0x1234, Zone: 2,
 		Helper:      Helper{Name: "ftp"},
 		SeqAdjOrig:  SequenceAdjust{Position: 1, OffsetBefore: 2, OffsetAfter: 3},
 		SeqAdjReply: SequenceAdjust{Position: 5, OffsetBefore: 6, OffsetAfter: 7},
@@ -519,7 +519,7 @@ func TestNewFlow(t *testing.T) {
 	)
 
 	want := Flow{
-		Status:  Status{Value: StatusNATMask},
+		Status:  StatusNATMask,
 		Timeout: 400,
 		TupleOrig: Tuple{
 			IP: IPTuple{

--- a/status_test.go
+++ b/status_test.go
@@ -34,12 +34,17 @@ func TestStatusMarshalTwoWay(t *testing.T) {
 		{
 			name:   "default values",
 			b:      []byte{0x00, 0x00, 0x00, 0x00},
-			status: Status{},
+			status: 0,
+		},
+		{
+			name:   "assured",
+			b:      []byte{0x00, 0x00, 0x00, 0xc},
+			status: StatusAssured | StatusConfirmed,
 		},
 		{
 			name:   "out of range, only highest bits flipped",
 			b:      []byte{0xFF, 0xFF, 0x80, 0x00},
-			status: Status{Value: 0xFFFF8000},
+			status: 0xFFFF8000,
 		},
 		{
 			name: "error, byte array too short",
@@ -54,9 +59,7 @@ func TestStatusMarshalTwoWay(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-
 		t.Run(tt.name, func(t *testing.T) {
-
 			// Wrap in status attribute container
 			nfa := netfilter.Attribute{
 				Type: uint16(ctaStatus),
@@ -64,14 +67,13 @@ func TestStatusMarshalTwoWay(t *testing.T) {
 			}
 
 			var s Status
-
 			err := s.unmarshal(mustDecodeAttribute(nfa))
 			if err != nil || tt.err != nil {
 				require.ErrorIs(t, err, tt.err)
 				return
 			}
 
-			require.Equal(t, tt.status.Value, s.Value, "unexpected unmarshal")
+			require.Equal(t, tt.status, s, "unexpected unmarshal")
 
 			ms := s.marshal()
 			assert.Equal(t, nfa, ms, "unexpected marshal")
@@ -80,55 +82,24 @@ func TestStatusMarshalTwoWay(t *testing.T) {
 }
 
 func TestStatusFieldTest(t *testing.T) {
-
-	var s Status
-
-	s.Value = StatusExpected
-	assert.Equal(t, true, s.Expected(), "expected")
-
-	s.Value = StatusSeenReply
-	assert.Equal(t, true, s.SeenReply(), "seenreply")
-
-	s.Value = StatusAssured
-	assert.Equal(t, true, s.Assured(), "assured")
-
-	s.Value = StatusConfirmed
-	assert.Equal(t, true, s.Confirmed(), "confirmed")
-
-	s.Value = StatusSrcNAT
-	assert.Equal(t, true, s.SrcNAT(), "srcnat")
-
-	s.Value = StatusDstNAT
-	assert.Equal(t, true, s.DstNAT(), "dstnat")
-
-	s.Value = StatusSeqAdjust
-	assert.Equal(t, true, s.SeqAdjust(), "seqadjust")
-
-	s.Value = StatusSrcNATDone
-	assert.Equal(t, true, s.SrcNATDone(), "srcnatdone")
-
-	s.Value = StatusDstNATDone
-	assert.Equal(t, true, s.DstNATDone(), "dstnatdone")
-
-	s.Value = StatusDying
-	assert.Equal(t, true, s.Dying(), "dying")
-
-	s.Value = StatusFixedTimeout
-	assert.Equal(t, true, s.FixedTimeout(), "fixedtimeout")
-
-	s.Value = StatusTemplate
-	assert.Equal(t, true, s.Template(), "template")
-
-	s.Value = StatusHelper
-	assert.Equal(t, true, s.Helper(), "helper")
-
-	s.Value = StatusOffload
-	assert.Equal(t, true, s.Offload(), "offload")
+	assert.Equal(t, true, StatusExpected.Expected(), "expected")
+	assert.Equal(t, true, StatusSeenReply.SeenReply(), "seenreply")
+	assert.Equal(t, true, StatusAssured.Assured(), "assured")
+	assert.Equal(t, true, StatusConfirmed.Confirmed(), "confirmed")
+	assert.Equal(t, true, StatusSrcNAT.SrcNAT(), "srcnat")
+	assert.Equal(t, true, StatusDstNAT.DstNAT(), "dstnat")
+	assert.Equal(t, true, StatusSeqAdjust.SeqAdjust(), "seqadjust")
+	assert.Equal(t, true, StatusSrcNATDone.SrcNATDone(), "srcnatdone")
+	assert.Equal(t, true, StatusDstNATDone.DstNATDone(), "dstnatdone")
+	assert.Equal(t, true, StatusDying.Dying(), "dying")
+	assert.Equal(t, true, StatusFixedTimeout.FixedTimeout(), "fixedtimeout")
+	assert.Equal(t, true, StatusTemplate.Template(), "template")
+	assert.Equal(t, true, StatusHelper.Helper(), "helper")
+	assert.Equal(t, true, StatusOffload.Offload(), "offload")
 }
 
 func TestStatusString(t *testing.T) {
-	full := Status{Value: 0xffffffff}
-	empty := Status{}
+	full, empty := Status(0xffffffff), Status(0)
 
 	wantFull := "EXPECTED|SEEN_REPLY|ASSURED|CONFIRMED|SRC_NAT|DST_NAT|SEQ_ADJUST|SRC_NAT_DONE|DST_NAT_DONE|" +
 		"DYING|FIXED_TIMEOUT|TEMPLATE|UNTRACKED|HELPER|OFFLOAD"

--- a/string.go
+++ b/string.go
@@ -51,7 +51,7 @@ func (s Status) String() string {
 
 	// Loop over the field's bits
 	for i, name := range names {
-		if s.Value&(1<<uint32(i)) != 0 {
+		if s&(1<<uint32(i)) != 0 {
 			if rs != "" {
 				rs += "|"
 			}

--- a/string_test.go
+++ b/string_test.go
@@ -40,7 +40,7 @@ func TestEventString(t *testing.T) {
 	// Event with Flow
 	ef := Event{Flow: &Flow{}}
 
-	ef.Flow.Status.Value = StatusAssured
+	ef.Flow.Status = StatusAssured
 
 	ef.Flow.TupleOrig = tpl
 


### PR DESCRIPTION
struct Status is gone, no need to set Status.Value explicitly. StatusFlag was renamed to Status, so it's now a u32.